### PR TITLE
Use new configuration file if it differs.

### DIFF
--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -15,7 +15,7 @@
 
 # Install Elasticsearch
 - name: "Install Elasticsearch package: ${elasticsearch.debian_package}"
-  shell: "dpkg -i -E ${tmp_dir}/${elasticsearch.debian_package} 2>&1 | grep skipping | wc -l"
+  shell: "dpkg -i -E --force-confnew ${tmp_dir}/${elasticsearch.debian_package} 2>&1 | grep skipping | wc -l"
   when_changed: ${elasticsearch_deb}
   tags:
     - elasticsearch


### PR DESCRIPTION
If you're upgrading to a newer version of elasticsearch, dpkg will complain the /etc/init.d/elasticsearch file has been changed since installation and ansible will wait indefinitely.
